### PR TITLE
chore: add link to issues and set repo to private

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,9 @@
         "type": "git",
         "url": "https://github.com/isabelle-np/isabelles-engineering-handbook.git"
     },
-    "homepage": "https://github.com/isabelle-np/isabelles-engineering-handbook#readme"
+    "homepage": "https://github.com/isabelle-np/isabelles-engineering-handbook#readme",
+    "bugs": {
+        "url": "https://github.com/isabelle-np/isabelles-engineering-handbook/issues"
+    },
+    "private": true
 }


### PR DESCRIPTION
Notes: 
I accidentally had the default branch set to `chore/init-repo` instead of main, so the first few commits were already in `main`. This PR just sets the project to private and links to the issues in GitHub.

Future TODO: add template for PR descriptions.